### PR TITLE
fix sampling of large corpora

### DIFF
--- a/include/corpus.h
+++ b/include/corpus.h
@@ -123,12 +123,12 @@ public:
     bool getPrint(int line);
     
     /**
-     *  @fn int getWC () const
+     *  @fn long long getWC () const
      *  @brief Accessor to the number of tokens of the Corpus
      *
      *  @return integer representing the token count
      */
-    int getWC() const;
+    long long getWC() const;
     
     /**
      *  @fn void removeLine (int line)
@@ -144,15 +144,15 @@ private:
     boost::shared_ptr<XenFile> ptrFile;     //!< Shared pointer on a XenFile wrapping the reference to the XenFile of the Corpus
     boost::shared_ptr<std::vector<std::string> > ptrText;     //!< Shared pointer on a vector of strings holding the Corpus text
     boost::shared_ptr<std::vector<int> > ptrPrint;      //!< Shared pointer on a vector of integers holding the printing status of the text
-    int wc;                 //!< Integer representing the tokens count
+    long long wc;                 //!< Integer representing the tokens count
     
     /**
-     *  @fn int wordCount ()
+     *  @fn long long wordCount ()
      *  @brief Counts the tokens in the Corpus text
      *
      *  @return integer representing the token count
      */
-    int wordCount();
+    long long wordCount();
     
     /**
      *  @fn void loadText ()

--- a/include/mode.h
+++ b/include/mode.h
@@ -60,17 +60,17 @@ public:
     
 protected:
     /**
-     *  @fn static void findSampleSize (boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp)
+     *  @fn static long long findSampleSize (boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp)
      *  @brief Finds the optimal sample size for the OOD Corpus 
      *
      *  @param idCorp :     in-domain Corpus
      *  @param oodCorp :    out-of-domain Corpus
      *  @return size of the required Corpus sample in percentage of the whole one
      */
-    static int findSampleSize(boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp);
+    static long long findSampleSize(boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp);
     
     /**
-     *  @fn static Corpus extractSample (boost::shared_ptr<Corpus> ptrCorp, int sSize, bool mean)
+     *  @fn static Corpus extractSample (boost::shared_ptr<Corpus> ptrCorp, long long sSize, bool mean)
      *  @brief Extracts a random sample from a give Corpus
      *
      *  @param ptrCorp :    Corpus from which the sample should be extracted
@@ -78,7 +78,7 @@ protected:
      *  @param mean :       true if we are in "mean" mode (not the same Corpus filename)
      *  @return extracted Corpus sample
      */
-    static Corpus extractSample(boost::shared_ptr<Corpus> ptrCorp, int sSize, bool mean);
+    static Corpus extractSample(boost::shared_ptr<Corpus> ptrCorp, long long sSize, bool mean);
 };
 
 #endif

--- a/include/xenoption.h
+++ b/include/xenoption.h
@@ -445,12 +445,12 @@ public:
     int getMaxEvalPC() const;
     
     /**
-     *  @fn void setSampleSize (int size)
+     *  @fn void setSampleSize (long long size)
      *  @brief Mutator to the out-of-domain sample size
      *
      *  @param size :   the out-of-domain sample size
      */
-    void setSampleSize(int size);
+    void setSampleSize(long long size);
     
     /**
      *  @fn void setStep (int step)

--- a/src/corpus.cpp
+++ b/src/corpus.cpp
@@ -104,7 +104,7 @@ bool Corpus::getPrint(int line) {
     return ptrPrint->operator[]((unsigned long) line) != 0;
 }
 
-int Corpus::getWC() const {
+long long Corpus::getWC() const {
 	return wc;
 }
 
@@ -117,8 +117,8 @@ void Corpus::loadText() {
     ptrPrint = boost::make_shared<std::vector<int> >(ptrText->size(), 1);
 }
 
-int Corpus::wordCount() {
-	int res = 0;
+long long Corpus::wordCount() {
+	long long res = 0;
     
 	for (unsigned int i = 0; i < ptrText->size(); i++) {
         res = res + XenCommon::wordCount(ptrText->operator[](i));

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -29,28 +29,20 @@
  */
 
 #include "../include/mode.h"
+#include <iostream>
 
 Mode::~Mode() {
     
 }
 
-int Mode::findSampleSize(boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp) {
-    int iW = idCorp->getWC();
-	int oW = oodCorp->getWC();
+long long Mode::findSampleSize(boost::shared_ptr<Corpus> idCorp, boost::shared_ptr<Corpus> oodCorp) {
+  long long iW = idCorp->getWC();
+	long long oW = oodCorp->getWC();
     
-	double res = (double)iW / (double)oW * 100;
-	int i = (int)(res + 0.5f);
-    
-	if (i == 0) { i = 1; }
-	if (i > 100) { i = 100; }
-    
-	return i;
+	return std::min(iW, oW);
 }
 
-Corpus Mode::extractSample(boost::shared_ptr<Corpus> ptrCorp, int sSize, bool mean) {
-	double res = (double)ptrCorp->getWC() * ((double)sSize / 100);
-	int max = (int)(res + 0.5f);
-    
+Corpus Mode::extractSample(boost::shared_ptr<Corpus> ptrCorp, long long sSize, bool mean) {
     std::string rnd = "";
     
     if (mean) {
@@ -68,7 +60,7 @@ Corpus Mode::extractSample(boost::shared_ptr<Corpus> ptrCorp, int sSize, bool me
         
         int count = 0;
         
-        while (count < max) {
+        while (count < sSize) {
             std::string line = ptrCorp->getLine(std::rand() % ptrCorp->getSize());
             out << line << std::endl;
             int n = XenCommon::wordCount(line);

--- a/src/xenoption.cpp
+++ b/src/xenoption.cpp
@@ -305,7 +305,7 @@ int XenOption::getMaxEvalPC() const {
     return opt->maxEvalPC;
 }
 
-void XenOption::setSampleSize(int size) {
+void XenOption::setSampleSize(long long size) {
     opt->sampleSize = size;
 }
 


### PR DESCRIPTION
This pull request fixes two issues:

### Integer overflow for large corpora

The corpus word counts were previously stored as signed integers which limits the size to ~2 billion words. We had more words so `XenC` tried to take a sample of negative size. Now it's `long long` which should be quite future-proof.

### Computation of sampling ratios

`XenC` originally computed the ratio of sizes between the in-domain and out-of-domain corpus as a percentage (integer). For very disproportionate corpora, this would lead to huge oversampling of the OOD corpus, since 1 per cent of a 10000-times larger corpus is still 100 times larger than the in-domain corpus.

And these corpora should be roughly the same size, so that the LMs are trained on comparably-sized data sets. I simplified the logic, now we simply take the smaller of the two words counts (in-domain or out-of-domain) as the sample size.